### PR TITLE
feat: implement dark theme

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -119,8 +119,8 @@ const config: Config = {
     },
     colorMode: {
       defaultMode: 'light',
-      disableSwitch: true,
-      respectPrefersColorScheme: false,
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/src/components/homepage/Footer.module.css
+++ b/src/components/homepage/Footer.module.css
@@ -4,6 +4,45 @@
   width: 100%;
 }
 
+html[data-theme='dark'] .footer {
+  background-color: #1e2128;
+  color: #e8e9eb;
+}
+
+html[data-theme='dark'] .brandTitle {
+  color: #ffffff;
+}
+
+html[data-theme='dark'] .sectionTitle {
+  color: #e8e9eb;
+}
+
+html[data-theme='dark'] .link {
+  color: rgba(232, 233, 235, 0.8);
+}
+
+html[data-theme='dark'] .link:hover {
+  color: #ffffff;
+}
+
+html[data-theme='dark'] .linkIcon img {
+  filter: none;
+  opacity: 0.8;
+}
+
+html[data-theme='dark'] .link:hover .linkIcon img {
+  filter: none;
+  opacity: 1;
+}
+
+html[data-theme='dark'] .bottomBar {
+  border-top-color: rgba(255, 255, 255, 0.12);
+}
+
+html[data-theme='dark'] .copyright {
+  color: rgba(232, 233, 235, 0.7);
+}
+
 .mainContent {
   padding: 120px 80px;
   display: flex;
@@ -113,6 +152,7 @@
   height: 14px;
   filter: brightness(0) saturate(100%) invert(75%) sepia(0%) saturate(0%)
     hue-rotate(0deg) brightness(91%) contrast(91%);
+  transition: filter 0.2s ease, opacity 0.2s ease;
 }
 
 .link:hover .linkIcon img {
@@ -141,8 +181,6 @@
   color: #b3b3b3;
   margin: 0;
 }
-
-/* Footer always has black background regardless of theme */
 
 /* Responsive design */
 @media (max-width: 1280px) {

--- a/src/components/homepage/GovernanceSystem.module.css
+++ b/src/components/homepage/GovernanceSystem.module.css
@@ -1,4 +1,4 @@
-.governanceSection {
+ .governanceSection {
   background-color: #000000;
   padding: 120px 48px;
   display: flex;
@@ -104,7 +104,7 @@
 .tabButton.active {
   opacity: 1;
   background-color: rgba(255, 121, 102, 0.1);
-  border-color: #ff7966;
+  border-color: var(--near-red);
 }
 
 .tabButton.active::before {
@@ -114,7 +114,7 @@
   top: 0;
   bottom: 0;
   width: 4px;
-  background-color: #ff7966;
+  background-color: var(--near-red);
   transform: scaleY(0);
   animation: slideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
@@ -300,7 +300,10 @@
   background-color: rgba(255, 255, 255, 0.05);
 }
 
-/* GovernanceSystem always has black background regardless of theme */
+/* Slightly soften background in dark mode while staying near-black */
+html[data-theme='dark'] .governanceSection {
+  background-color: #050608;
+}
 
 /* Responsive design */
 @media (max-width: 1280px) {
@@ -374,7 +377,7 @@
 
 .accordionHeader.expanded {
   background-color: rgba(255, 121, 102, 0.05);
-  border-left-color: #ff7966;
+  border-left-color: var(--near-red);
 }
 
 .accordionTitleButton {
@@ -413,7 +416,7 @@
 .accordionIcon {
   flex-shrink: 0;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  color: #ff7966;
+  color: var(--near-red);
   width: 40px;
   height: 40px;
   display: block;
@@ -638,7 +641,7 @@
   font-family: 'FK Grotesk', var(--ifm-font-family-base);
   font-size: 16px;
   font-weight: 500;
-  color: #ff7966;
+  color: var(--near-red);
   text-decoration: none;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;

--- a/src/components/homepage/Header.module.css
+++ b/src/components/homepage/Header.module.css
@@ -37,25 +37,25 @@ html {
 
 /* Header wrapper background when scrolled */
 .headerWrapper.scrolled .header {
-  background-color: rgba(255, 255, 255, 1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
+  background-color: var(--ifm-navbar-background-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25) !important;
 }
 
 /* Ensure background covers full header when scrolled */
 .headerWrapper.scrolled .iconContainer,
 .headerWrapper.scrolled .container {
-  background-color: rgba(255, 255, 255, 1);
+  background-color: var(--ifm-navbar-background-color);
 }
 
 /* Header wrapper background when menu is active */
 .headerWrapper.menuActive .header {
-  background-color: rgba(255, 255, 255, 1);
+  background-color: var(--ifm-navbar-background-color);
 }
 
 /* Ensure background covers full header when menu is active */
 .headerWrapper.menuActive .iconContainer,
 .headerWrapper.menuActive .container {
-  background-color: rgba(255, 255, 255, 1);
+  background-color: var(--ifm-navbar-background-color);
 }
 
 /* Icon container - left side */
@@ -85,7 +85,13 @@ html {
   transition: filter 0.3s ease;
 }
 
-/* Logo stays inverted (black) when header has white background */
+html[data-theme='dark'] .logo,
+html[data-theme='dark'] .headerWrapper.scrolled .logo,
+html[data-theme='dark'] .headerWrapper.menuActive .logo {
+  filter: none;
+}
+
+/* Logo stays inverted (black) in light mode when scrolled/menu open */
 .headerWrapper.scrolled .logo,
 .headerWrapper.menuActive .logo {
   filter: invert(1);
@@ -123,7 +129,7 @@ html {
   font-size: 20px;
   font-weight: 700;
   line-height: 24px;
-  color: #000000;
+  color: var(--ifm-navbar-link-color);
   margin: 0;
   white-space: nowrap;
   flex-shrink: 0;
@@ -137,6 +143,64 @@ html {
   gap: 40px;
 }
 
+.themeToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background-color: rgba(255, 255, 255, 0.9);
+  font-family: 'FK Grotesk', var(--ifm-font-family-base);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ifm-navbar-link-color);
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.themeToggle:hover {
+  background-color: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
+  transform: translateY(-1px);
+}
+
+.themeToggleIcon {
+  font-size: 14px;
+}
+
+.themeToggleLabel {
+  font-weight: 500;
+}
+
+html[data-theme='dark'] .themeToggle {
+  background-color: rgba(15, 16, 24, 0.96);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #f5f5f6;
+}
+
+html[data-theme='dark'] .themeToggle:hover {
+  background-color: #1b1e27;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.6);
+}
+
+/* Dark mode: navbar borders and logo */
+html[data-theme='dark'] .iconContainer {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
+html[data-theme='dark'] .container {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+  border-left-color: rgba(255, 255, 255, 0.12);
+}
+
+/* Dark mode: participate button hover stays readable */
+html[data-theme='dark'] .participateButton:hover {
+  background-color: var(--near-red);
+  color: #ffffff;
+}
+
 /* Menu items */
 .menuItem {
   display: flex;
@@ -146,14 +210,14 @@ html {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #000000;
+  color: var(--ifm-navbar-link-color);
   text-decoration: none;
   white-space: nowrap;
 }
 
 .menuItem:hover {
   text-decoration: none;
-  color: #000000;
+  color: var(--ifm-navbar-link-hover-color);
 }
 
 .menuLink {
@@ -161,19 +225,19 @@ html {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #000000;
+  color: var(--ifm-navbar-link-color);
   text-decoration: none;
 }
 
 .menuLink:hover {
   text-decoration: none;
-  color: #000000;
+  color: var(--ifm-navbar-link-hover-color);
 }
 
 .externalIcon {
   width: 12px;
   height: 12px;
-  color: #000000;
+  color: var(--ifm-navbar-link-color);
   opacity: 0.6;
 }
 
@@ -183,8 +247,8 @@ html {
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  background-color: #000000;
-  color: #ffffff;
+  background-color: var(--ifm-heading-color);
+  color: var(--ifm-background-color);
   border: none;
   border-radius: 4px;
   font-family: 'FK Grotesk', var(--ifm-font-family-base);
@@ -197,8 +261,8 @@ html {
 }
 
 .participateButton:hover {
-  background-color: #1a1a1a;
-  color: #ffffff;
+  background-color: var(--ifm-navbar-link-hover-color);
+  color: var(--ifm-background-color);
   text-decoration: none;
   transform: translateY(-1px);
 }
@@ -221,7 +285,7 @@ html {
 .hamburgerLine {
   width: 100%;
   height: 2px;
-  background-color: #000000;
+  background-color: var(--ifm-navbar-link-color);
   transition: all 0.3s ease;
   transform-origin: center;
   position: absolute;
@@ -319,7 +383,7 @@ html {
     top: 56px;
     left: 0;
     right: 0;
-    background-color: #ffffff;
+    background-color: var(--ifm-navbar-background-color);
     flex-direction: column;
     align-items: stretch;
     gap: 0;
@@ -333,6 +397,11 @@ html {
     z-index: 1000;
   }
 
+  html[data-theme='dark'] .menuContainer {
+    border-bottom-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  }
+
   .menuContainer.menuOpen {
     transform: translateY(0);
     opacity: 1;
@@ -343,6 +412,10 @@ html {
     font-size: 16px;
     padding: 12px 0;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  html[data-theme='dark'] .menuItem {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
   }
 
   .menuItem:last-child {

--- a/src/components/homepage/Header.module.css
+++ b/src/components/homepage/Header.module.css
@@ -146,18 +146,25 @@ html[data-theme='dark'] .headerWrapper.menuActive .logo {
 .themeToggle {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: 999px;
+  justify-content: center;
+  padding: 8px;
+  border-radius: 50%;
   border: 1px solid rgba(0, 0, 0, 0.12);
   background-color: rgba(255, 255, 255, 0.9);
   font-family: 'FK Grotesk', var(--ifm-font-family-base);
-  font-size: 13px;
   line-height: 1;
   cursor: pointer;
   color: var(--ifm-navbar-link-color);
   transition: background-color 0.15s ease, border-color 0.15s ease,
     transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.themeToggleDesktop {
+  display: inline-flex;
+}
+
+.themeToggleMobile {
+  display: none;
 }
 
 .themeToggle:hover {
@@ -167,11 +174,14 @@ html[data-theme='dark'] .headerWrapper.menuActive .logo {
 }
 
 .themeToggleIcon {
-  font-size: 14px;
+  display: block;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
 }
 
-.themeToggleLabel {
-  font-weight: 500;
+html[data-theme='dark'] .themeToggleIcon {
+  filter: invert(1);
 }
 
 html[data-theme='dark'] .themeToggle {
@@ -282,6 +292,10 @@ html[data-theme='dark'] .participateButton:hover {
   position: relative;
 }
 
+.mobileNavActions {
+  display: none;
+}
+
 .hamburgerLine {
   width: 100%;
   height: 2px;
@@ -374,7 +388,22 @@ html[data-theme='dark'] .participateButton:hover {
   /* Show hamburger button */
   .hamburger {
     display: flex;
+  }
+
+  .mobileNavActions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
     margin-left: auto;
+  }
+
+  .themeToggleDesktop {
+    display: none !important;
+  }
+
+  .themeToggleMobile {
+    display: inline-flex !important;
+    margin-right: 12px;
   }
 
   /* Mobile menu container */

--- a/src/components/homepage/Header.tsx
+++ b/src/components/homepage/Header.tsx
@@ -162,16 +162,33 @@ const Header: React.FC = () => {
             </h1>
           </Link>
 
-          <button
-            className={styles.hamburger}
-            onClick={toggleMenu}
-            aria-label="Toggle menu"
-            aria-expanded={isMenuOpen}
-          >
-            <span className={styles.hamburgerLine}></span>
-            <span className={styles.hamburgerLine}></span>
-            <span className={styles.hamburgerLine}></span>
-          </button>
+          <div className={styles.mobileNavActions}>
+            <button
+              className={styles.hamburger}
+              onClick={toggleMenu}
+              aria-label="Toggle menu"
+              aria-expanded={isMenuOpen}
+            >
+              <span className={styles.hamburgerLine}></span>
+              <span className={styles.hamburgerLine}></span>
+              <span className={styles.hamburgerLine}></span>
+            </button>
+
+            <button
+              type="button"
+              className={`${styles.themeToggle} ${styles.themeToggleMobile}`}
+              onClick={toggleTheme}
+              aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+            >
+              <img
+                src={useBaseUrl(theme === 'dark' ? '/img/sun-icon.svg' : '/img/moon-icon.svg')}
+                alt=""
+                className={styles.themeToggleIcon}
+                width={20}
+                height={20}
+              />
+            </button>
+          </div>
 
           <nav
             className={`${styles.menuContainer} ${isMenuOpen ? styles.menuOpen : ''}`}
@@ -236,16 +253,17 @@ const Header: React.FC = () => {
             })}
             <button
               type="button"
-              className={styles.themeToggle}
+              className={`${styles.themeToggle} ${styles.themeToggleDesktop}`}
               onClick={toggleTheme}
               aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
             >
-              <span className={styles.themeToggleIcon}>
-                {theme === 'dark' ? '☀' : '🌙'}
-              </span>
-              <span className={styles.themeToggleLabel}>
-                {theme === 'dark' ? 'Light' : 'Dark'}
-              </span>
+              <img
+                src={useBaseUrl(theme === 'dark' ? '/img/sun-icon.svg' : '/img/moon-icon.svg')}
+                alt=""
+                className={styles.themeToggleIcon}
+                width={20}
+                height={20}
+              />
             </button>
           </nav>
         </div>

--- a/src/components/homepage/Header.tsx
+++ b/src/components/homepage/Header.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useCallback,
   useMemo,
+  useEffect,
 } from 'react';
 import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
@@ -38,6 +39,7 @@ const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const animationFrameRef = useRef<number | null>(null);
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
 
   // Dynamically determine the edit URL based on current page
   const editUrl = useMemo(() => {
@@ -84,6 +86,33 @@ const Header: React.FC = () => {
 
   const toggleMenu = useCallback(() => {
     setIsMenuOpen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const doc = document.documentElement;
+    const stored =
+      (window.localStorage.getItem('theme') as 'light' | 'dark' | null) ?? null;
+    const current =
+      (doc.getAttribute('data-theme') as 'light' | 'dark' | null) ?? null;
+    const initial = stored || current || 'light';
+    doc.setAttribute('data-theme', initial);
+    doc.classList.remove('theme-light', 'theme-dark');
+    doc.classList.add(`theme-${initial}`);
+    setTheme(initial);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    setTheme((prev) => {
+      const next = prev === 'dark' ? 'light' : 'dark';
+      const doc = document.documentElement;
+      doc.setAttribute('data-theme', next);
+      doc.classList.remove('theme-light', 'theme-dark');
+      doc.classList.add(`theme-${next}`);
+      window.localStorage.setItem('theme', next);
+      return next;
+    });
   }, []);
 
   useLayoutEffect(() => {
@@ -205,6 +234,19 @@ const Header: React.FC = () => {
                 </Link>
               );
             })}
+            <button
+              type="button"
+              className={styles.themeToggle}
+              onClick={toggleTheme}
+              aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+            >
+              <span className={styles.themeToggleIcon}>
+                {theme === 'dark' ? '☀' : '🌙'}
+              </span>
+              <span className={styles.themeToggleLabel}>
+                {theme === 'dark' ? 'Light' : 'Dark'}
+              </span>
+            </button>
           </nav>
         </div>
       </div>

--- a/src/components/homepage/Hero.module.css
+++ b/src/components/homepage/Hero.module.css
@@ -1,6 +1,6 @@
 .hero {
   position: relative;
-  background-color: #ffffff;
+  background-color: var(--ifm-background-color);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -23,6 +23,22 @@
   background-repeat: no-repeat;
   pointer-events: none;
   z-index: 1;
+}
+
+html[data-theme='dark'] .heroBackground {
+  opacity: 0.4;
+}
+
+html[data-theme='dark'] .heroBackground::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(5, 6, 8, 0.3) 0%,
+    rgba(5, 6, 8, 0.6) 100%
+  );
+  pointer-events: none;
 }
 
 /* Content wrapper */
@@ -74,7 +90,7 @@
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: -0.03em;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
 }
 
@@ -83,7 +99,7 @@
   font-size: 32px;
   font-weight: 500;
   line-height: 1.2;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
 }
 
@@ -92,7 +108,7 @@
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  background-color: #000000;
+  background-color: var(--ifm-heading-color);
   border: none;
   border-radius: 4px;
   padding: 8px 24px 8px 8px;
@@ -104,7 +120,7 @@
 }
 
 .specialButton:hover {
-  background-color: #1a1a1a;
+  background-color: var(--ifm-navbar-link-hover-color);
   transform: translateY(-1px);
   text-decoration: none;
 }
@@ -115,7 +131,7 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  background-color: #ffffff;
+  background-color: var(--ifm-background-color);
   border-radius: 2px;
   padding: 8px;
   box-sizing: border-box;
@@ -127,12 +143,16 @@
   filter: brightness(0) saturate(100%);
 }
 
+html[data-theme='dark'] .logoIcon img {
+  filter: none;
+}
+
 .buttonLabel {
   font-family: 'FK Grotesk', var(--ifm-font-family-base);
   font-size: 16px;
   font-weight: 500;
   line-height: 1.5;
-  color: #ffffff;
+  color: var(--ifm-background-color);
   white-space: nowrap;
 }
 
@@ -150,8 +170,8 @@
   flex-direction: column;
   gap: 0;
   padding: 32px;
-  background-color: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid rgba(0, 0, 0, 0.08);
   box-sizing: border-box;
   min-width: 300px;
 }
@@ -161,7 +181,7 @@
   font-size: 32px;
   font-weight: 500;
   line-height: 1.25;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
 }
 
@@ -170,7 +190,7 @@
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
-  color: #000000;
+  color: var(--ifm-font-color-base);
   margin: 0;
 }
 

--- a/src/components/homepage/How.module.css
+++ b/src/components/homepage/How.module.css
@@ -1,5 +1,5 @@
 .sectionSplitTextVisual {
-  background-color: #ffffff;
+  background-color: var(--ifm-background-color);
   padding: 120px 48px;
   display: flex;
   flex-direction: column;
@@ -42,7 +42,7 @@
   font-weight: 600;
   line-height: 1.2;
   letter-spacing: -0.48px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   flex: 1 0 0;
   min-width: 1px;
@@ -72,7 +72,11 @@
   width: 100%;
   position: relative;
   flex-shrink: 0;
-  background: linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1)
+  );
 }
 
 .textContainer {
@@ -141,7 +145,7 @@
 
 .bg {
   position: absolute;
-  background-color: #ffffff;
+  background-color: var(--ifm-background-surface-color);
   top: 0;
   left: 0;
   right: 0;
@@ -180,7 +184,7 @@
   font-size: 24px;
   font-weight: 500;
   line-height: 30px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   width: min-content;
   min-width: 100%;
@@ -293,7 +297,7 @@
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   white-space: nowrap;
   text-align: left;
@@ -324,7 +328,7 @@
 }
 
 .learnMoreLink:hover .learnMoreText {
-  border-bottom-color: #000000;
+  border-bottom-color: var(--ifm-heading-color);
 }
 
 .learnMoreLink:hover .arrowIcon {

--- a/src/components/homepage/Roadmap.module.css
+++ b/src/components/homepage/Roadmap.module.css
@@ -1,5 +1,5 @@
 .roadmapSection {
-  background-color: #ffffff;
+  background-color: var(--ifm-background-color);
   padding: 120px 48px;
   display: flex;
   flex-direction: column;
@@ -39,7 +39,7 @@
   font-size: 44px;
   font-weight: 500;
   line-height: 1.2;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   flex: 1 0 0;
   min-width: 1px;
@@ -65,7 +65,7 @@
   align-items: center;
   justify-content: center;
   transition: all 0.2s ease;
-  color: #000000;
+  color: var(--ifm-heading-color);
 }
 
 .navButton:hover {
@@ -80,7 +80,11 @@
 .divider {
   height: 1px;
   width: 100%;
-  background: linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1)
+  );
 }
 
 .roadmapContent {
@@ -104,7 +108,7 @@
   width: 80px;
   background: linear-gradient(
     to right,
-    rgba(255, 255, 255, 1) 0%,
+    var(--ifm-background-color) 0%,
     rgba(255, 255, 255, 0.9) 50%,
     rgba(255, 255, 255, 0) 100%
   );
@@ -122,7 +126,7 @@
   width: 80px;
   background: linear-gradient(
     to left,
-    rgba(255, 255, 255, 1) 0%,
+    var(--ifm-background-color) 0%,
     rgba(255, 255, 255, 0.9) 50%,
     rgba(255, 255, 255, 0) 100%
   );
@@ -230,7 +234,7 @@
   font-size: 20px;
   font-weight: 400;
   line-height: 24px;
-  color: #000000;
+  color: var(--ifm-font-color-base);
   margin: 0;
   text-align: center;
   width: 100%;
@@ -248,7 +252,7 @@
 }
 
 .roadmapCard {
-  background-color: #ffffff;
+  background-color: var(--ifm-background-surface-color);
   border: 1px solid rgba(0, 0, 0, 0.1);
   padding: 16px;
   display: flex;
@@ -308,7 +312,7 @@
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   width: 100%;
 }

--- a/src/components/homepage/StructureRoles.module.css
+++ b/src/components/homepage/StructureRoles.module.css
@@ -1,5 +1,5 @@
 .sectionSplitTextVisual {
-  background-color: #f9f9fa;
+  background-color: var(--ifm-background-surface-color);
   padding: 120px 48px;
   display: flex;
   flex-direction: column;
@@ -42,7 +42,7 @@
   font-size: 44px;
   font-weight: 500;
   line-height: 1.2;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   text-align: center;
   width: 100%;
@@ -58,7 +58,11 @@
   width: 100%;
   position: relative;
   flex-shrink: 0;
-  background: linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1)
+  );
 }
 
 .content {
@@ -162,7 +166,7 @@
   font-size: 20px;
   font-weight: 400;
   line-height: 28px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   display: inline-flex;
   align-items: center;
@@ -187,7 +191,7 @@
 }
 
 .arrowButton.open {
-  background-color: #ff7966;
+  background-color: var(--near-red);
 }
 
 .arrowButton.open:hover {
@@ -199,13 +203,13 @@
   height: 56px;
   position: relative;
   flex-shrink: 0;
-  color: #000000;
+  color: var(--ifm-heading-color);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   transform: rotate(0deg);
 }
 
 .arrowButton.open svg {
-  color: #f9f9fa;
+  color: var(--ifm-background-surface-color);
   transform: rotate(180deg);
 }
 
@@ -310,7 +314,7 @@
 
 .contentStrong {
   font-weight: 600;
-  color: #000000;
+  color: var(--ifm-heading-color);
 }
 
 .spacer {
@@ -338,7 +342,7 @@
   font-family: 'FK Grotesk', var(--ifm-font-family-base);
   font-size: 14px;
   font-weight: 600;
-  color: #000000;
+  color: var(--ifm-heading-color);
   white-space: nowrap;
 }
 

--- a/src/components/homepage/What.module.css
+++ b/src/components/homepage/What.module.css
@@ -1,5 +1,5 @@
 .sectionSplitTextVisual {
-  background-color: #f9f9fa;
+  background-color: var(--ifm-background-surface-color);
   padding: 120px 48px;
   display: flex;
   flex-direction: column;
@@ -51,7 +51,7 @@
 
 .bg {
   position: absolute;
-  background-color: #ffffff;
+  background-color: var(--ifm-background-color);
   top: 0;
   left: 0;
   right: 0;
@@ -81,7 +81,7 @@
   font-size: 24px;
   font-weight: 500;
   line-height: 30px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   margin: 0;
   width: 100%;
   display: flex;
@@ -145,7 +145,7 @@
 
 .topLine,
 .bottomLine {
-  background-color: #000000;
+  background-color: var(--ifm-heading-color);
   height: 1px;
   width: 80px;
   flex-shrink: 0;
@@ -163,7 +163,7 @@
 .arrowUpRight svg {
   width: 40px;
   height: 40px;
-  color: #000000;
+  color: var(--ifm-heading-color);
   display: block;
   transition: transform 0.3s ease;
   transform: translate(0, 0);

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -7,7 +7,7 @@
 /* Font imports */
 @import './fonts.css';
 
-/* NEAR Brand Colors */
+/* NEAR Brand Colors and global theme tokens */
 :root {
   /* Font stack with FK Grotesk as primary font */
   --ifm-font-family-base:
@@ -38,32 +38,67 @@
   --ifm-color-primary-lighter: #ff9285;
   --ifm-color-primary-lightest: #ffb0a3;
 
-  /* Background and surface colors */
+  /* Background and surface colors (light) */
   --ifm-background-color: #ffffff;
   --ifm-background-surface-color: #f9f9fa;
   --ifm-navbar-background-color: #f9f9fa;
 
-  /* Text colors */
+  /* Text colors (light) */
   --ifm-font-color-base: #000000;
   --ifm-heading-color: #000000;
   --ifm-navbar-link-color: #000000;
   --ifm-menu-color: #000000;
 
-  /* Hover states */
+  /* Hover states (light) */
   --ifm-navbar-link-hover-color: #ff7966;
   --ifm-menu-color-active: #e91409;
   --ifm-link-color: #e91409;
   --ifm-link-hover-color: #ff6b55;
   --ifm-breadcrumb-color-active: #e91409;
 
-  /* Code blocks */
+  /* Code blocks (light) */
   --ifm-code-background: #f9f9fa;
   --ifm-pre-background: #f9f9fa;
 
-  /* Sidebar */
+  /* Sidebar (light) */
   --ifm-sidebar-background: #f9f9fa;
   --ifm-sidebar-color: #000000;
   --ifm-sidebar-color-active: #ff7966;
+}
+
+/* ============================
+   Dark theme overrides
+   Docusaurus sets data-theme="dark" on <html>
+   ============================ */
+html[data-theme='dark'] {
+  color-scheme: dark;
+
+  /* Background and surface colors (dark) */
+  --ifm-background-color: #050608;
+  --ifm-background-surface-color: #0e1015;
+  --ifm-navbar-background-color: rgba(5, 6, 8, 0.96);
+
+  /* Text colors (dark) */
+  --ifm-font-color-base: #f5f5f6;
+  --ifm-heading-color: #ffffff;
+  --ifm-navbar-link-color: #f5f5f6;
+  --ifm-menu-color: #f5f5f6;
+
+  /* Hover states (dark) */
+  --ifm-navbar-link-hover-color: #ffb0a3;
+  --ifm-menu-color-active: #ffb0a3;
+  --ifm-link-color: #ff8777;
+  --ifm-link-hover-color: #ffb0a3;
+  --ifm-breadcrumb-color-active: #ff8777;
+
+  /* Code blocks (dark) */
+  --ifm-code-background: #10121a;
+  --ifm-pre-background: #10121a;
+
+  /* Sidebar (dark) */
+  --ifm-sidebar-background: #050608;
+  --ifm-sidebar-color: #f5f5f6;
+  --ifm-sidebar-color-active: #ffb0a3;
 }
 
 /* Fix external link icon alignment */
@@ -170,6 +205,16 @@ nav.navbar {
   --ifm-footer-title-color: var(--near-black);
 }
 
+/* Footer styling for dark theme */
+html[data-theme='dark'] .footer--dark {
+  background-color: #050608 !important;
+  --ifm-footer-background-color: #050608;
+  --ifm-footer-color: #f5f5f6;
+  --ifm-footer-link-color: #f5f5f6;
+  --ifm-footer-link-hover-color: #ffb0a3;
+  --ifm-footer-title-color: #f5f5f6;
+}
+
 /* Footer border styling */
 .footer {
   border-top: 1px solid rgba(0, 0, 0, 0.1);
@@ -207,6 +252,16 @@ nav.navbar {
   color: var(--near-black) !important;
 }
 
+/* Blog author colors in dark mode */
+html[data-theme='dark'] .avatar__name,
+html[data-theme='dark'] .avatar__name a,
+html[data-theme='dark'] .blog-wrapper .avatar__name,
+html[data-theme='dark'] .blog-wrapper .avatar__name a,
+html[data-theme='dark'] .blog-post-page .avatar__name,
+html[data-theme='dark'] .blog-post-page .avatar__name a {
+  color: #f5f5f6 !important;
+}
+
 /* Blog tag styling */
 .blog-tags-list-page .tag,
 .blog-tags-post-list-page .tag,
@@ -226,6 +281,24 @@ article .tag:hover,
   background-color: #e0e0e0 !important;
   color: var(--near-black) !important;
   text-decoration: none !important;
+}
+
+/* Blog tags in dark mode */
+html[data-theme='dark'] .blog-tags-list-page .tag,
+html[data-theme='dark'] .blog-tags-post-list-page .tag,
+html[data-theme='dark'] article .tag,
+html[data-theme='dark'] [class*='tagRegular'] {
+  background-color: #111217 !important;
+  color: #f5f5f6 !important;
+  border-color: #232530 !important;
+}
+
+html[data-theme='dark'] .blog-tags-list-page .tag:hover,
+html[data-theme='dark'] .blog-tags-post-list-page .tag:hover,
+html[data-theme='dark'] article .tag:hover,
+html[data-theme='dark'] [class*='tagRegular']:hover {
+  background-color: #1b1e27 !important;
+  color: #ffffff !important;
 }
 
 /* Performance optimizations for smooth scrolling */
@@ -286,6 +359,21 @@ article header h2 a:hover,
 .blog-wrapper article h2 a:hover {
   color: #ff5f47 !important;
   text-decoration: none;
+}
+
+/* Blog titles in dark mode */
+html[data-theme='dark'] article h2[class*='blogPostTitle'] a,
+html[data-theme='dark'] article header h2 a,
+html[data-theme='dark'] .blog-list-page article h2 a,
+html[data-theme='dark'] .blog-wrapper article h2 a {
+  color: #ff8777 !important;
+}
+
+html[data-theme='dark'] article h2[class*='blogPostTitle'] a:hover,
+html[data-theme='dark'] article header h2 a:hover,
+html[data-theme='dark'] .blog-list-page article h2 a:hover,
+html[data-theme='dark'] .blog-wrapper article h2 a:hover {
+  color: #ffb0a3 !important;
 }
 
 /* Docs CTA button - themed for documentation */

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,4 +1,5 @@
 .homepage {
   min-height: 100vh;
   overflow-x: hidden;
+  background-color: var(--ifm-background-color);
 }

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -42,12 +42,14 @@ export default function LayoutWrapper(props: Props): ReactNode {
   }, []);
 
   return (
-    <>
-      <Header />
-      <div style={{ paddingTop: '72px' }}>
-        <Layout {...customProps} />
-      </div>
-      <Footer />
-    </>
+    <Layout {...customProps}>
+      <>
+        <Header />
+        <div style={{ paddingTop: '72px' }}>
+          {props.children}
+        </div>
+        <Footer />
+      </>
+    </Layout>
   );
 }

--- a/static/img/moon-icon.svg
+++ b/static/img/moon-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/img/sun-icon.svg
+++ b/static/img/sun-icon.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="4" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
Adds a full light/dark theme to the site with a persistent toggle and theme-aware styling across the homepage, navbar, footer.
## What's included
- **Theme toggle** – Icon-only sun/moon toggle in the navbar.
- **Global tokens** – CSS variables for background, text, and accent colors in `global.css` with `html[data-theme='dark']` overrides
- **Updated areas** – Hero, Header, Footer, and the other sections
- **Persistence** – Theme choice stored in `localStorage` and synced with `data-theme` on `<html>`
## How to test
1. Use the theme toggle in the top-right (desktop) or next to the hamburger (mobile).
2. Reload and confirm the selected theme is preserved.
